### PR TITLE
Fix clock positioning when custom status bar views are already present at index 1

### DIFF
--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/StatusbarMods.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/StatusbarMods.java
@@ -141,6 +141,7 @@ public class StatusbarMods extends XposedModPack {
 	private ViewGroup mStatusbarStartSide = null;
 	private View mCenteredIconArea = null;
 	private LinearLayout mSystemIconArea = null;
+	private int mOriginalLeftClockIndex = -1;
 	private static int currentClockColor = 0;
 	private static final ArrayList<StatusbarTextColorCallback> mTextColorCallbacks = new ArrayList<>();
 	//    private Object STB = null;
@@ -651,6 +652,12 @@ public class StatusbarMods extends XposedModPack {
 
 					mSystemIconArea = mPhoneStatusbarView.findViewById(idOf("statusIcons"));
 
+					//remember the clock's existing position.
+					//this preserves views inserted by other modules such as Iconify.
+					if (mClockView.getParent() == mStatusbarStartSide) {
+						mOriginalLeftClockIndex = mStatusbarStartSide.indexOfChild(mClockView);
+					}
+
 					createCenterIconArea();
 
 					makeLeftSplitArea();
@@ -1102,33 +1109,70 @@ public class StatusbarMods extends XposedModPack {
 
 	//region clock and date related
 	private void placeClock() {
-		ViewGroup parent = (ViewGroup) mClockView.getParent();
+		if (mClockView == null) return;
+
+		ViewGroup currentParent =
+				mClockView.getParent() instanceof ViewGroup
+						? (ViewGroup) mClockView.getParent()
+						: null;
+
 		ViewGroup targetArea = null;
-		Integer index = null;
+		Integer targetIndex = null;
 
 		switch (clockPosition) {
 			case POSITION_LEFT:
 				if (notificationAreaMultiRow) {
 					targetArea = mLeftExtraRowContainer;
-					index = 0;
+					targetIndex = 0;
 				} else {
 					targetArea = mStatusbarStartSide;
-					index = 1;
+					
+					//do not remove and re-add the clock if it is already in the normal left-side
+					//re-adding it at hard-coded index 1 changes the ordering of views inserted by other modules,such as Iconify's status-bar logo
+					if (currentParent == targetArea) {
+						mClockView.setPadding(0, 0, leftClockPadding, 0);
+						return;
+					}
+
+					//restore the position observed when SystemUI originally attached when returning from Center/Right to Left rather than blindly using 1
+					if (mOriginalLeftClockIndex >= 0) {
+						targetIndex = Math.min(mOriginalLeftClockIndex, targetArea.getChildCount());
+					} else {
+						//preserve old behaviour as fallback
+						targetIndex = Math.min(1, targetArea.getChildCount());
+					}
 				}
+
 				mClockView.setPadding(0, 0, leftClockPadding, 0);
 				break;
 			case POSITION_CENTER:
 				targetArea = (ViewGroup) mCenteredIconArea;
-				mClockView.setPadding(rightClockPadding, 0, rightClockPadding, 0);
+
+				mClockView.setPadding(
+						rightClockPadding,
+						0,
+						rightClockPadding,
+						0
+				);
 				break;
 			case POSITION_RIGHT:
-				mClockView.setPadding(rightClockPadding, 0, 0, 0);
-				targetArea = ((ViewGroup) mSystemIconArea.getParent());
+				targetArea = (ViewGroup) mSystemIconArea.getParent();
+
+				mClockView.setPadding(rightClockPadding, 0, 0,0);
 				break;
 		}
-		parent.removeView(mClockView);
-		if (index != null) {
-			targetArea.addView(mClockView, index);
+		if (targetArea == null) return;
+
+		if (currentParent == targetArea) {
+			return;
+		}
+
+		if (currentParent != null) {
+			currentParent.removeView(mClockView);
+		}
+
+		if (targetIndex != null) {
+			targetArea.addView(mClockView, targetIndex);
 		} else {
 			//noinspection DataFlowIssue
 			targetArea.addView(mClockView);

--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/StatusbarMods.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/StatusbarMods.java
@@ -653,8 +653,7 @@ public class StatusbarMods extends XposedModPack {
 
 					mSystemIconArea = mPhoneStatusbarView.findViewById(idOf("statusIcons"));
 
-					//remember the clock's original index
-					//this preserves views inserted by other modules such as Iconify
+					//remember the clock's original index to preserve the position of views inserted by other modules, such as Iconify
 					if (mClockView.getParent() == mStatusbarStartSide) {
 						mOriginalLeftClockIndex = mStatusbarStartSide.indexOfChild(mClockView);
 					}
@@ -1133,13 +1132,13 @@ public class StatusbarMods extends XposedModPack {
 					targetArea = mStatusbarStartSide;	
 					
 					//do not remove and re-add the clock if it is already in the normal left-side
-					//re-adding it at hard-coded index 1 changes the ordering of views inserted by other modules,such as Iconify's status-bar logo
+					//re-adding it at hard-coded index 1 changes the ordering of views inserted by other modules, such as Iconify's status-bar logo
 					if (currentParent == targetArea) {
 						mClockView.setPadding(0, 0, leftClockPadding, 0);
 						return;
 					}
 
-					//restore the position observed when SystemUI originally attached rather than blindly inserting at index 1.
+					//restore the position observed when SystemUI originally attached rather than blindly inserting at index 1
 					if (mOriginalLeftClockIndex >= 0) {
 						targetIndex = Math.min(mOriginalLeftClockIndex, targetArea.getChildCount());
 					} else {

--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/StatusbarMods.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/StatusbarMods.java
@@ -142,7 +142,6 @@ public class StatusbarMods extends XposedModPack {
 	private View mCenteredIconArea = null;
 	private LinearLayout mSystemIconArea = null;
 	private int mOriginalLeftClockIndex = -1;
-	private int mOriginalLeftClockPaddingStart = -1;
 	private View mLeftClockSpacer = null;
 	private static int currentClockColor = 0;
 	private static final ArrayList<StatusbarTextColorCallback> mTextColorCallbacks = new ArrayList<>();
@@ -654,11 +653,10 @@ public class StatusbarMods extends XposedModPack {
 
 					mSystemIconArea = mPhoneStatusbarView.findViewById(idOf("statusIcons"));
 
-					//remember the clock's original left-side position and padding
+					//remember the clock's original index
 					//this preserves views inserted by other modules such as Iconify
 					if (mClockView.getParent() == mStatusbarStartSide) {
 						mOriginalLeftClockIndex = mStatusbarStartSide.indexOfChild(mClockView);
-						mOriginalLeftClockPaddingStart = mClockView.getPaddingStart();
 					}
 
 					createCenterIconArea();
@@ -1132,19 +1130,12 @@ public class StatusbarMods extends XposedModPack {
 					targetArea = mLeftExtraRowContainer;
 					targetIndex = 0;
 				} else {
-					targetArea = mStatusbarStartSide;
-
-					// restore the START padding that the clock had when SystemUI first attached.
-					int originalStartPadding =
-							mOriginalLeftClockPaddingStart >= 0
-									? mOriginalLeftClockPaddingStart
-									: mClockView.getPaddingStart();
-
+					targetArea = mStatusbarStartSide;	
 					
 					//do not remove and re-add the clock if it is already in the normal left-side
 					//re-adding it at hard-coded index 1 changes the ordering of views inserted by other modules,such as Iconify's status-bar logo
 					if (currentParent == targetArea) {
-						mClockView.setPaddingRelative(originalStartPadding,	mClockView.getPaddingTop(), leftClockPadding, mClockView.getPaddingBottom());
+						mClockView.setPadding(0, 0, leftClockPadding, 0);
 						return;
 					}
 
@@ -1156,7 +1147,7 @@ public class StatusbarMods extends XposedModPack {
 						targetIndex = Math.min(1, targetArea.getChildCount());
 					}
 
-					mClockView.setPaddingRelative(originalStartPadding,	mClockView.getPaddingTop(), leftClockPadding, mClockView.getPaddingBottom());
+					mClockView.setPadding(0, 0, leftClockPadding, 0);
 				}
 
 				break;
@@ -1193,6 +1184,7 @@ public class StatusbarMods extends XposedModPack {
 			targetArea.addView(mClockView);
 		}
 
+		//add clock spacer when another view is present at the left of the clock
 		if (clockPosition == POSITION_LEFT && !notificationAreaMultiRow) {
 			int clockIndex = mStatusbarStartSide.indexOfChild(mClockView);
 			if (clockIndex > 1) {

--- a/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/StatusbarMods.java
+++ b/app/src/main/java/sh/siava/pixelxpert/xposed/modpacks/systemui/StatusbarMods.java
@@ -142,6 +142,8 @@ public class StatusbarMods extends XposedModPack {
 	private View mCenteredIconArea = null;
 	private LinearLayout mSystemIconArea = null;
 	private int mOriginalLeftClockIndex = -1;
+	private int mOriginalLeftClockPaddingStart = -1;
+	private View mLeftClockSpacer = null;
 	private static int currentClockColor = 0;
 	private static final ArrayList<StatusbarTextColorCallback> mTextColorCallbacks = new ArrayList<>();
 	//    private Object STB = null;
@@ -652,10 +654,11 @@ public class StatusbarMods extends XposedModPack {
 
 					mSystemIconArea = mPhoneStatusbarView.findViewById(idOf("statusIcons"));
 
-					//remember the clock's existing position.
-					//this preserves views inserted by other modules such as Iconify.
+					//remember the clock's original left-side position and padding
+					//this preserves views inserted by other modules such as Iconify
 					if (mClockView.getParent() == mStatusbarStartSide) {
 						mOriginalLeftClockIndex = mStatusbarStartSide.indexOfChild(mClockView);
+						mOriginalLeftClockPaddingStart = mClockView.getPaddingStart();
 					}
 
 					createCenterIconArea();
@@ -1111,6 +1114,10 @@ public class StatusbarMods extends XposedModPack {
 	private void placeClock() {
 		if (mClockView == null) return;
 
+		if (clockPosition != POSITION_LEFT && mLeftClockSpacer != null && mLeftClockSpacer.getParent() instanceof ViewGroup) {
+			((ViewGroup) mLeftClockSpacer.getParent()).removeView(mLeftClockSpacer);
+		}
+
 		ViewGroup currentParent =
 				mClockView.getParent() instanceof ViewGroup
 						? (ViewGroup) mClockView.getParent()
@@ -1126,24 +1133,32 @@ public class StatusbarMods extends XposedModPack {
 					targetIndex = 0;
 				} else {
 					targetArea = mStatusbarStartSide;
+
+					// restore the START padding that the clock had when SystemUI first attached.
+					int originalStartPadding =
+							mOriginalLeftClockPaddingStart >= 0
+									? mOriginalLeftClockPaddingStart
+									: mClockView.getPaddingStart();
+
 					
 					//do not remove and re-add the clock if it is already in the normal left-side
 					//re-adding it at hard-coded index 1 changes the ordering of views inserted by other modules,such as Iconify's status-bar logo
 					if (currentParent == targetArea) {
-						mClockView.setPadding(0, 0, leftClockPadding, 0);
+						mClockView.setPaddingRelative(originalStartPadding,	mClockView.getPaddingTop(), leftClockPadding, mClockView.getPaddingBottom());
 						return;
 					}
 
-					//restore the position observed when SystemUI originally attached when returning from Center/Right to Left rather than blindly using 1
+					//restore the position observed when SystemUI originally attached rather than blindly inserting at index 1.
 					if (mOriginalLeftClockIndex >= 0) {
 						targetIndex = Math.min(mOriginalLeftClockIndex, targetArea.getChildCount());
 					} else {
-						//preserve old behaviour as fallback
+						//preserve old behaviour as fallback.
 						targetIndex = Math.min(1, targetArea.getChildCount());
 					}
+
+					mClockView.setPaddingRelative(originalStartPadding,	mClockView.getPaddingTop(), leftClockPadding, mClockView.getPaddingBottom());
 				}
 
-				mClockView.setPadding(0, 0, leftClockPadding, 0);
 				break;
 			case POSITION_CENTER:
 				targetArea = (ViewGroup) mCenteredIconArea;
@@ -1176,6 +1191,17 @@ public class StatusbarMods extends XposedModPack {
 		} else {
 			//noinspection DataFlowIssue
 			targetArea.addView(mClockView);
+		}
+
+		if (clockPosition == POSITION_LEFT && !notificationAreaMultiRow) {
+			int clockIndex = mStatusbarStartSide.indexOfChild(mClockView);
+			if (clockIndex > 1) {
+				if (mLeftClockSpacer == null) {
+					mLeftClockSpacer = new View(mContext);
+					mLeftClockSpacer.setLayoutParams(new LinearLayout.LayoutParams(leftClockPadding, MATCH_PARENT));
+				}
+				mStatusbarStartSide.addView(mLeftClockSpacer, clockIndex);
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes status bar clock ordering when another view is already inserted at index 1, where the clock normally sits (e.g. when using a custom status bar icon in Iconify).

This is done by storing the clock's initial index when it is attached and reusing that index instead of always placing it at index 1.

**Fully tested and working on a Pixel 9 Pro with Android 17 CP2A.260805.005.**

**Before**
<img width="359" height="152" alt="Screenshot_20260821-215945~2" src="https://github.com/user-attachments/assets/f25d1a7d-fb4e-4153-b555-74b631f26b06" />

**After**
<img width="350" height="149" alt="Screenshot_20260821-215654~2" src="https://github.com/user-attachments/assets/da347fb6-2ff7-4a91-b1fe-09002b8a0466" />